### PR TITLE
Fix paste command to support paths with spaces

### DIFF
--- a/src/pe2loaddata/__main__.py
+++ b/src/pe2loaddata/__main__.py
@@ -181,7 +181,7 @@ def headless(
                 )
 
             os.system(
-                'paste -d "," {} {} > {}'.format(
+                'paste -d "," "{}" "{}" > "{}"'.format(
                     output, os.path.join(tmpdir, "illum.csv"), illum_output
                 )
             )


### PR DESCRIPTION
This PR implements a simple improvement to correctly handle input/output paths containing spaces. 

I tested this change locally and it ran without issues.  