### PR TITLE
Report per-channel metadata

### DIFF
--- a/src/pe2loaddata/content/item/item_handler.py
+++ b/src/pe2loaddata/content/item/item_handler.py
@@ -55,6 +55,10 @@ class ItemHandler(xml.sax.handler.ContentHandler):
         except:
             return False
 
+    @channel_name.setter
+    def channel_name(self,channel_name):
+        self.__channel_name = channel_name
+
     @property
     def channel_id(self):
         """The integer channel id


### PR DESCRIPTION
Right now, we take all experimental metadata from one image in the image set, so in cases where that info is common (Objective magnification) that's fine, in cases where it isn't (Excitation wavelength), we have values from one but not all channels.

This PR adds code to check all values for all images, if the value is constant, report it once, otherwise, report it per-channel. 