### PR TITLE
sets remote=False by default 

### DIFF
--- a/src/pe2loaddata/__main__.py
+++ b/src/pe2loaddata/__main__.py
@@ -59,6 +59,7 @@ def headless(
     illum_output=False,
     sub_string_out="",
     sub_string_in="",
+    remote=False,
 ):
     channels, metadata = transformer.load_config(configuration)
 


### PR DESCRIPTION
to prevent "UnboundLocalError: local variable 'remote' referenced before assignment"
See https://github.com/broadinstitute/pe2loaddata/issues/39